### PR TITLE
node-fetch types as prod dependency

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@mediaurl/schema": "^1.2.1",
     "@types/express": "4.17.11",
+    "@types/node-fetch": "^2.5.8",
     "agent-base": "6.0.2",
     "body-parser": "1.19.0",
     "commander": "7.0.0",
@@ -31,7 +32,6 @@
     "@types/lodash": "4.14.168",
     "@types/morgan": "1.9.2",
     "@types/ms": "0.7.31",
-    "@types/node-fetch": "2.5.8",
     "@types/pug": "2.0.4",
     "@types/semver": "7.3.4",
     "@types/supertest": "2.0.10",


### PR DESCRIPTION
`node-fetch` types are [referenced](https://github.com/mediaurl/mediaurl-js/blob/4cb2d90c960690be41523cf4cbfa08df3503bdf0/packages/sdk/src/tasks/types.ts#L8) in prod build, dependency should be moved `devDependencies` -> `dependencies`

Current situation: ctx.fetch function is untyped