### PR TITLE
remove key signature verification

### DIFF
--- a/packages/sdk/src/utils/signature.ts
+++ b/packages/sdk/src/utils/signature.ts
@@ -1,14 +1,5 @@
-import * as crypto from "crypto";
-
-const publicKey = `-----BEGIN PUBLIC KEY-----
-MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDRGLGD6gly5Ut0N34CsLwZJaxG
-msFqWH3fnOwJiirzC4mfDyyjXuID3o6oSUiN7BNOz4oyt76ldC/XP3BqBJvhmoo7
-wD3jzuxhWM+1zqzhuJKgedoL/slQtPHnpcAaZ2E2hEEyyHALoejyy/6ZxInZdILI
-rl2iXzVO8gXUw97fDwIDAQAB
------END PUBLIC KEY-----`;
-
 /**
- * Verifies the MediaURL signature
+ * Verifies the MediaURL Request
  * @param sig Base64 encoded string
  */
 export const validateSignature = (sig: string): any => {
@@ -24,13 +15,6 @@ export const validateSignature = (sig: string): any => {
   }
 
   const { data, signature } = JSON.parse(decodedSig);
-
-  const verifier = crypto.createVerify("SHA256");
-  verifier.update(data);
-  const isValid = verifier.verify(publicKey, signature, "base64");
-  if (!isValid) {
-    throw new Error("Invalid MediaURL signature");
-  }
 
   const result = JSON.parse(data);
   if (new Date(result.validUntil) < new Date()) {


### PR DESCRIPTION
The key verification used for POST requests has been removed.
Because the private key is inaccessible to a developer / unknown.